### PR TITLE
Fix: Application hangs during initialization due to deadlock

### DIFF
--- a/client/include/client/config_manager.hpp
+++ b/client/include/client/config_manager.hpp
@@ -39,7 +39,7 @@ private:
 
     std::string runtimeDir_;
     std::map<std::string, std::string> configData_;
-    mutable std::mutex mutex_;
+    mutable std::recursive_mutex mutex_;
 
     bool createDirectoryStructure();
     bool testDirectoryWritable(const std::string& path);

--- a/client/src/config_manager.cpp
+++ b/client/src/config_manager.cpp
@@ -15,7 +15,7 @@ ConfigManager& ConfigManager::getInstance() {
 }
 
 bool ConfigManager::setRuntimeDirectory(const std::string& path) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     // Verify directory exists
     if (!std::filesystem::exists(path)) {
@@ -46,17 +46,17 @@ bool ConfigManager::setRuntimeDirectory(const std::string& path) {
 }
 
 std::string ConfigManager::getRuntimeDirectory() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     return runtimeDir_;
 }
 
 bool ConfigManager::hasRuntimeDirectory() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     return !runtimeDir_.empty();
 }
 
 std::string ConfigManager::getDataLogPath() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     if (runtimeDir_.empty()) {
         return "";
     }
@@ -64,7 +64,7 @@ std::string ConfigManager::getDataLogPath() const {
 }
 
 std::string ConfigManager::getConfigPath() const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
     if (runtimeDir_.empty()) {
         return "";
     }
@@ -201,14 +201,14 @@ bool ConfigManager::saveToJson() {
 }
 
 bool ConfigManager::saveConfig(const std::string& key, const std::string& value) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     configData_[key] = value;
     return saveToJson();
 }
 
 std::string ConfigManager::getConfig(const std::string& key) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     auto it = configData_.find(key);
     if (it != configData_.end()) {
@@ -218,7 +218,7 @@ std::string ConfigManager::getConfig(const std::string& key) {
 }
 
 bool ConfigManager::saveTcpSettings(const std::string& host, int port, bool autoReconnect, int reconnectDelay) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     configData_["tcp_host"] = host;
     configData_["tcp_port"] = std::to_string(port);
@@ -229,7 +229,7 @@ bool ConfigManager::saveTcpSettings(const std::string& host, int port, bool auto
 }
 
 bool ConfigManager::getTcpSettings(std::string& host, int& port, bool& autoReconnect, int& reconnectDelay) {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard<std::recursive_mutex> lock(mutex_);
 
     auto hostIt = configData_.find("tcp_host");
     auto portIt = configData_.find("tcp_port");

--- a/client/src/main.cpp
+++ b/client/src/main.cpp
@@ -142,7 +142,7 @@ public:
         if (parser.isNoGuiMode()) {
             cout << "Running in console mode (no GUI). Press Ctrl+C to exit.\n";
             cout << "Listening for JSON stream...\n\n";
-            
+
             while (true) {
                 std::this_thread::sleep_for(std::chrono::seconds(1)); // Run forever in console
             }


### PR DESCRIPTION
The application was hanging during initialization because of a deadlock in `config_manager.cpp`

1. saveConfig() acquired a lock on `mutex_`
2. It then called saveToJson()
3. saveToJson() called getConfigPath()
4. getConfigPath() tried to acquire the same `mutex_` that was already locked
-> deadlock from the thread waiting on itself to release the lock